### PR TITLE
Using PRIORITY_MIN

### DIFF
--- a/Mimicker/app/src/main/java/com/microsoft/mimickeralarm/scheduling/AlarmNotificationManager.java
+++ b/Mimicker/app/src/main/java/com/microsoft/mimickeralarm/scheduling/AlarmNotificationManager.java
@@ -111,6 +111,7 @@ public class AlarmNotificationManager {
 
         builder.setContentTitle(context.getString(R.string.notification_next_alarm_content_title));
         builder.setContentText(DateTimeUtilities.getDayAndTimeAlarmDisplayString(context, alarmTime));
+        builder.setPriority(Notification.PRIORITY_MIN);
 
         Intent startIntent = new Intent(context, AlarmMainActivity.class);
         startIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);


### PR DESCRIPTION
- Changed persistent notification's priority to PRIORITY_MIN so that it doesn't clutter the user's status bar or lock screen.
